### PR TITLE
fix(workflows): include repo name in Slack notification titles

### DIFF
--- a/.github/workflows/release-version.yml
+++ b/.github/workflows/release-version.yml
@@ -137,7 +137,7 @@ jobs:
           SLACK_COLOR: 'good'
           SLACK_ICON_EMOJI: ':fish:'
           SLACK_MESSAGE: ${{ steps.changelog.outputs.clean_changelog }}
-          SLACK_TITLE: 'Release Version & Changelog'
+          SLACK_TITLE: 'Release Version & Changelog — ${{ github.repository }}'
           SLACK_USERNAME: Github
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
 
@@ -147,8 +147,8 @@ jobs:
         env:
           SLACK_COLOR: 'warning'
           SLACK_ICON_EMOJI: ':warning:'
-          SLACK_MESSAGE: 'Release ${{ steps.changelog.outputs.tag }} succeeded, but failed to merge into ${{ inputs.sync_branch }}. Please merge manually.'
-          SLACK_TITLE: 'Manual Merge Required'
+          SLACK_MESSAGE: 'Release ${{ steps.changelog.outputs.tag }} in ${{ github.repository }} succeeded, but failed to merge into ${{ inputs.sync_branch }}. Please merge manually.'
+          SLACK_TITLE: 'Manual Merge Required — ${{ github.repository }}'
           SLACK_USERNAME: Github
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
 


### PR DESCRIPTION
### Related Issue/Request:

N/A — identified during Slack channel monitoring; release notifications lacked repo context.

### This PR...

Adds the repository name (`github.repository`) to the Slack notification titles and failure message in the `release-version.yml` workflow, so teams can quickly identify which repo triggered the notification.

### Type of Change:

- [ ] 💥 This is a **breaking change** (complete the Breaking Changes section below)

### Changes:

- Add `github.repository` to the success notification `SLACK_TITLE` (e.g. `Release Version & Changelog — maker-tech/ci-github-actions-shared`)
- Add `github.repository` to the merge-failure notification `SLACK_TITLE`
- Include `github.repository` in the merge-failure `SLACK_MESSAGE` body for additional clarity

### Breaking Changes:

N/A

### Notes:

Uses `${{ github.repository }}` which returns the `owner/repo` format. This is the caller's repo (not the shared workflow repo), so each consumer will see their own repo name in notifications.

---

## Testing

### How was this tested?

- [x] Dry-run only (documentation/comment changes)

### Test repository (if applicable):

N/A — Slack env variables are purely additive string changes; no logic affected.

---

## Security Checklist:

- [x] No secrets, tokens, or credentials are hardcoded
- [x] No internal URLs, IPs, or infrastructure details exposed
- [x] No client-specific identifiers or project names
- [x] All sensitive values use `secrets:` or `inputs:` parameters
- [x] Git history reviewed for accidental secret commits

---

## Documentation:

- [x] Input parameters are documented with descriptions
- [ ] README.md updated (if adding new workflows)
- [x] Inline comments explain non-obvious logic

---

## Review Checklist:

- [x] Workflow syntax is valid (`actionlint` runs automatically on PRs that touch workflow files)
- [x] `secrets.*` is NOT used in step-level `if` conditions ([see docs](https://docs.github.com/en/actions/learn-github-actions/contexts#context-availability))
- [x] Inputs have sensible defaults where appropriate
- [x] Error handling covers common failure scenarios
- [x] Slack/notification steps use `if: failure()` correctly
- [x] Version pinning used for third-party actions (SHA or tag, not `@main`)
- [x] Backward compatible with existing consumers (or breaking change documented)
- [ ] Tested with at least one consuming repository