### PR TITLE
docs: add missing permissions blocks to README wrapper examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,6 +397,8 @@ The shared workflows do not enforce environment rules. For Vercel, use their nat
 - No access to other client repositories
 - No access to this organisation's secrets
 
+> **Permissions:** Each shared workflow declares the minimum `GITHUB_TOKEN` permissions it needs. However, due to GitHub's intersection model, the calling workflow must also declare at least the same permissions. If your repository uses restrictive default permissions, add a `permissions` block to your wrapper workflow. See the [Common Wrapper Examples](#common-wrapper-examples) for the correct values.
+
 ## Versioning & Updates
 
 This repository follows semantic versioning:


### PR DESCRIPTION
### Related Issue/Request:

N/A — identified during documentation review.

### This PR...

Adds missing `permissions` blocks to README wrapper examples that would fail at runtime for repos with restrictive default token permissions, and documents the underlying GitHub intersection model.

### Type of Change:

- [ ] 💥 This is a **breaking change** (complete the Breaking Changes section below)

### Changes:

- Add `permissions: contents: write` to the "Promote dev → uat" wrapper example
- Add `permissions: contents: write` to the "Release on main" wrapper example
- Add `permissions: pull-requests: read` to the "Lint PR title" wrapper example
- Add a callout to the Security Model section explaining GitHub's `GITHUB_TOKEN` intersection model and linking to the wrapper examples

### Breaking Changes:

N/A

### Notes:

GitHub reusable workflows use an intersection model — the effective `GITHUB_TOKEN` permissions are the minimum of the caller's permissions and the called workflow's declared permissions. The Chromatic, CI-only, and E2E examples only need `contents: read` (the default) so they are unaffected.

---

## Testing

### How was this tested?

- [x] Dry-run only (documentation/comment changes)

### Test repository (if applicable):

N/A

---

## Security Checklist:

- [x] No secrets, tokens, or credentials are hardcoded
- [x] No internal URLs, IPs, or infrastructure details exposed
- [x] No client-specific identifiers or project names
- [x] All sensitive values use `secrets:` or `inputs:` parameters
- [x] Git history reviewed for accidental secret commits

---

## Documentation:

- [ ] Input parameters are documented with descriptions
- [x] README.md updated (if adding new workflows)
- [ ] Inline comments explain non-obvious logic

---

## Review Checklist:

- [ ] Workflow syntax is valid (`actionlint` runs automatically on PRs that touch workflow files)
- [ ] `secrets.*` is NOT used in step-level `if` conditions ([see docs](https://docs.github.com/en/actions/learn-github-actions/contexts#context-availability))
- [ ] Inputs have sensible defaults where appropriate
- [ ] Error handling covers common failure scenarios
- [ ] Slack/notification steps use `if: failure()` correctly
- [ ] Version pinning used for third-party actions (SHA or tag, not `@main`)
- [x] Backward compatible with existing consumers (or breaking change documented)
- [ ] Tested with at least one consuming repository