### PR TITLE
feat(github): add CI inheritance and remediation repo labels

### DIFF
--- a/.github/repo-labels.json
+++ b/.github/repo-labels.json
@@ -1,32 +1,57 @@
 [
-  {
-    "name": "dependencies",
-    "color": "0366d6",
-    "description": "Dependency updates"
-  },
-  {
-    "name": "automated",
-    "color": "ededed",
-    "description": "Automated PR"
-  },
-  {
-    "name": "dev-deps",
-    "color": "1d76db",
-    "description": "Development dependency updates"
-  },
-  {
-    "name": "prod-deps",
-    "color": "d93f0b",
-    "description": "Production dependency updates"
-  },
-  {
-    "name": "github-actions",
-    "color": "000000",
-    "description": "GitHub Actions updates"
-  },
-  {
-    "name": "security",
-    "color": "b60205",
-    "description": "Security vulnerability fix"
-  }
+	{
+		"name": "dependencies",
+		"color": "0366d6",
+		"description": "Dependency updates"
+	},
+	{
+		"name": "automated",
+		"color": "ededed",
+		"description": "Automated PR"
+	},
+	{
+		"name": "dev-deps",
+		"color": "1d76db",
+		"description": "Development dependency updates"
+	},
+	{
+		"name": "prod-deps",
+		"color": "d93f0b",
+		"description": "Production dependency updates"
+	},
+	{
+		"name": "github-actions",
+		"color": "000000",
+		"description": "GitHub Actions updates"
+	},
+	{
+		"name": "security",
+		"color": "b60205",
+		"description": "Security vulnerability fix"
+	},
+	{
+		"name": "ci-inheritance",
+		"color": "6f42c1",
+		"description": "Shared CI workflow inheritance update"
+	},
+	{
+		"name": "breaking-change",
+		"color": "e11d48",
+		"description": "Contains breaking changes"
+	},
+	{
+		"name": "nodejs",
+		"color": "026e00",
+		"description": "Node.js version update"
+	},
+	{
+		"name": "remediation-attempted",
+		"color": "D93F0B",
+		"description": "Automated fix already pushed — do not retry"
+	},
+	{
+		"name": "remediation-needs-review",
+		"color": "FBCA04",
+		"description": "Automated analysis complete — human decision needed"
+	}
 ]


### PR DESCRIPTION
### Related Issue/Request:

N/A

### This PR...

Extends the shared `repo-labels.json` preset with labels used for CI inheritance, breaking-change tracking, Node.js bumps, and automated remediation workflows. Re-indents the file with tabs for consistency.

### Type of Change:

- [ ] 💥 This is a **breaking change** (complete the Breaking Changes section below)

### Changes:

- Add `ci-inheritance`, `breaking-change`, and `nodejs` labels
- Add `remediation-attempted` and `remediation-needs-review` labels for automated fix flows
- Reformat existing label entries with tab indentation

### Breaking Changes:

N/A

### Notes:

Consumers that sync labels from this file will get the new definitions on the next label sync run.

---

## Testing

### How was this tested?

Configuration-only change; not executed in CI from this PR.

- [ ] Tested locally with [act](https://github.com/nektos/act) or similar
- [ ] Tested in a feature branch of a consuming repository
- [ ] Created a draft PR in a client repo to verify workflow execution
- [x] Dry-run only (documentation/comment changes)

### Test repository (if applicable):

N/A

---

## Security Checklist:

- [x] No secrets, tokens, or credentials are hardcoded
- [x] No internal URLs, IPs, or infrastructure details exposed
- [x] No client-specific identifiers or project names
- [x] All sensitive values use `secrets:` or `inputs:` parameters
- [x] Git history reviewed for accidental secret commits

---

## Documentation:

- [ ] Input parameters are documented with descriptions
- [ ] README.md updated (if adding new workflows)
- [ ] Inline comments explain non-obvious logic

---

## Review Checklist:

- [ ] Workflow syntax is valid (`actionlint` runs automatically on PRs that touch workflow files)
- [ ] `secrets.*` is NOT used in step-level `if` conditions ([see docs](https://docs.github.com/en/actions/learn-github-actions/contexts#context-availability))
- [ ] Inputs have sensible defaults where appropriate
- [ ] Error handling covers common failure scenarios
- [ ] Slack/notification steps use `if: failure()` correctly
- [ ] Version pinning used for third-party actions (SHA or tag, not `@main`)
- [ ] Backward compatible with existing consumers (or breaking change documented)
- [ ] Tested with at least one consuming repository